### PR TITLE
(p5_structs_methods_interfaces) Area & Perimeter of Rectangle struct

### DIFF
--- a/fundamentals/p5_structs_methods_interfaces/geometry.go
+++ b/fundamentals/p5_structs_methods_interfaces/geometry.go
@@ -1,9 +1,14 @@
 package p5_structs_methods_interfaces
 
-func Perimeter(length, width float32) float32 {
-	return 2 * (length + width)
+func Perimeter(rectangle Rectangle) float32 {
+	return 2 * (rectangle.Length + rectangle.Width)
 }
 
-func Area(length, width float32) float32 {
-	return length * width
+func Area(rectangle Rectangle) float32 {
+	return rectangle.Length * rectangle.Width
+}
+
+type Rectangle struct {
+	Length float32
+	Width  float32
 }

--- a/fundamentals/p5_structs_methods_interfaces/geometry.go
+++ b/fundamentals/p5_structs_methods_interfaces/geometry.go
@@ -1,0 +1,5 @@
+package p5_structs_methods_interfaces
+
+func Perimeter(length, width float32) float32 {
+	return 2 * (length + width)
+}

--- a/fundamentals/p5_structs_methods_interfaces/geometry.go
+++ b/fundamentals/p5_structs_methods_interfaces/geometry.go
@@ -3,3 +3,7 @@ package p5_structs_methods_interfaces
 func Perimeter(length, width float32) float32 {
 	return 2 * (length + width)
 }
+
+func Area(length, width float32) float32 {
+	return length * width
+}

--- a/fundamentals/p5_structs_methods_interfaces/geometry_test.go
+++ b/fundamentals/p5_structs_methods_interfaces/geometry_test.go
@@ -1,0 +1,16 @@
+package p5_structs_methods_interfaces
+
+import "testing"
+
+func assertHelper(t testing.TB, got, want float32) {
+	if want != got {
+		t.Errorf("got %f, want %f", got, want)
+	}
+}
+
+func TestPerimeter(t *testing.T) {
+	got := Perimeter(11, 9)
+	want := float32(40)
+
+	assertHelper(t, got, want)
+}

--- a/fundamentals/p5_structs_methods_interfaces/geometry_test.go
+++ b/fundamentals/p5_structs_methods_interfaces/geometry_test.go
@@ -14,3 +14,10 @@ func TestPerimeter(t *testing.T) {
 
 	assertHelper(t, got, want)
 }
+
+func TestArea(t *testing.T) {
+	got := Area(11, 9)
+	want := float32(99)
+
+	assertHelper(t, got, want)
+}

--- a/fundamentals/p5_structs_methods_interfaces/geometry_test.go
+++ b/fundamentals/p5_structs_methods_interfaces/geometry_test.go
@@ -1,10 +1,13 @@
 package p5_structs_methods_interfaces
 
-import "testing"
+import (
+	"learn-go-with-tests/utils"
+	"testing"
+)
 
 func assertHelper(t testing.TB, got, want float32) {
 	// shouldn't use this direct floating point
-	if want != got {
+	if !utils.AreEqual(got, want) {
 		t.Errorf("got %.2f, want %.2f", got, want)
 	}
 }

--- a/fundamentals/p5_structs_methods_interfaces/geometry_test.go
+++ b/fundamentals/p5_structs_methods_interfaces/geometry_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func assertHelper(t testing.TB, got, want float32) {
 	if want != got {
-		t.Errorf("got %f, want %f", got, want)
+		t.Errorf("got %.2f, want %.2f", got, want)
 	}
 }
 

--- a/fundamentals/p5_structs_methods_interfaces/geometry_test.go
+++ b/fundamentals/p5_structs_methods_interfaces/geometry_test.go
@@ -3,20 +3,25 @@ package p5_structs_methods_interfaces
 import "testing"
 
 func assertHelper(t testing.TB, got, want float32) {
+	// shouldn't use this direct floating point
 	if want != got {
 		t.Errorf("got %.2f, want %.2f", got, want)
 	}
 }
 
 func TestPerimeter(t *testing.T) {
-	got := Perimeter(11, 9)
+	rectangle := Rectangle{11, 9}
+
+	got := Perimeter(rectangle)
 	want := float32(40)
 
 	assertHelper(t, got, want)
 }
 
 func TestArea(t *testing.T) {
-	got := Area(11, 9)
+	rectangle := Rectangle{11, 9}
+
+	got := Area(rectangle)
 	want := float32(99)
 
 	assertHelper(t, got, want)

--- a/utils/math_utils.go
+++ b/utils/math_utils.go
@@ -1,0 +1,16 @@
+package utils
+
+import "math"
+
+// floating point comparison delta https://stackoverflow.com/a/47969546/3679900
+const FLOAT32_DELTA float32 = 1e-9
+
+// fn needs to be named (starting) with uppercase to be 'import-able'
+func AreEqual(f1, f2 float32, maxDeltaOpt ...float32) bool {
+	maxDelta := FLOAT32_DELTA
+	if len(maxDeltaOpt) > 0 {
+		maxDelta = maxDeltaOpt[0]
+	}
+
+	return float32(math.Abs(float64(f1-f2))) <= maxDelta
+}

--- a/utils/math_utils.go
+++ b/utils/math_utils.go
@@ -6,6 +6,7 @@ import "math"
 const FLOAT32_DELTA float32 = 1e-9
 
 // fn needs to be named (starting) with uppercase to be 'import-able'
+// default value maxDeltaOpt in Go fns https://stackoverflow.com/a/23650312/3679900
 func AreEqual(f1, f2 float32, maxDeltaOpt ...float32) bool {
 	maxDelta := FLOAT32_DELTA
 	if len(maxDeltaOpt) > 0 {

--- a/utils/math_utils_test.go
+++ b/utils/math_utils_test.go
@@ -7,6 +7,7 @@ import (
 
 func assertHelper(t testing.TB, got, want bool, f1, f2 float32) {
 	if got != want {
+		// format specifier for boolean https://stackoverflow.com/a/7059760/3679900
 		t.Errorf("got %t, want %t for f1=%.2f, f2=%.2f", got, want, f1, f2)
 	}
 }

--- a/utils/math_utils_test.go
+++ b/utils/math_utils_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"math"
+	"testing"
+)
+
+func assertHelper(t testing.TB, got, want bool, f1, f2 float32) {
+	if got != want {
+		t.Errorf("got %t, want %t for f1=%.2f, f2=%.2f", got, want, f1, f2)
+	}
+}
+
+func TestAreEqual(t *testing.T) {
+	t.Run("equal numbers", func(t *testing.T) {
+		pi := float32(22) / 7
+
+		got := AreEqual(pi, pi)
+		want := true
+
+		assertHelper(t, got, want, pi, pi)
+	})
+
+	t.Run("approx equal numbers 1", func(t *testing.T) {
+		pi1 := float32(22) / 7
+		pi2 := (float32(22) / 7) + 1e-10
+
+		got := AreEqual(pi1, pi2)
+		want := true
+
+		assertHelper(t, got, want, pi1, pi1)
+	})
+
+	t.Run("approx equal numbers 2", func(t *testing.T) {
+		pi1 := float32(22) / 7
+		pi2 := (float32(22) / 7) + 1e-9
+
+		got := AreEqual(pi1, pi2)
+		want := true
+
+		assertHelper(t, got, want, pi1, pi1)
+	})
+
+	t.Run("approx non equal numbers 1", func(t *testing.T) {
+		pi1 := float32(22) / 7
+		pi2 := (float32(22) / 7) + 1e-5
+
+		got := AreEqual(pi1, pi2)
+		want := false
+
+		assertHelper(t, got, want, pi1, pi1)
+	})
+
+	t.Run("approx equal numbers 2", func(t *testing.T) {
+		pi1 := float32(22) / 7
+		pi2 := float32(math.Sqrt(10))
+
+		got := AreEqual(pi1, pi2)
+		want := false
+
+		assertHelper(t, got, want, pi1, pi1)
+	})
+}


### PR DESCRIPTION
- [dev][unittest] (p5_structs_methods_interfaces) Create Perimeter of rect
- [dev][unittest] (p5_structs_methods_interfaces) Create Area of rect
- [debug-unittest] (p5_structs_methods_interfaces) Round test failure output
- [modify] (p5_structs_methods_interfaces) Use Rectangle struct
- [refactor] (utils) Create 'math_utils' with float32 AreEqual fn
- [unittest] (utils/math_utils) Write tests for float32 AreEqual
- [doc] (utils/math_utils) Add ref links
